### PR TITLE
Feature: Sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A SEO package made for maximum customization and flexibility.
 - [Configuration](#configuration)
 - [Documentation](#documentation)
 - [Usage](#usage)
+  - [Sections](#sections)
   - [Laravel-Mix Integration](#laravel-mix-integration)
   - [Schema.org Integration](#schemaorg-integration)
 - [Upgrading from 1.0 to **2.0**](#upgrading)
@@ -168,6 +169,45 @@ seo()->meta('copyright', 'Roman Zipp');
 ```
 
 For more information see the [structs documentation](docs/2-STRUCTS.md).
+
+## Sections
+
+You can add structs to different **sections** by calling the `section('foo')` method on the `SeoService` instance or passing it as the first attribute to the `seo('foo')` helper method.
+
+Sections allow you to create certain namespaces for Structs which can be used in many different ways: Distinct between "frontend" and "admin" page sections or "head" and "body" view sections.
+
+### Using sections
+
+```php
+// This struct will be added to the "default" section
+seo()->twitter('card', 'summary');
+
+// This struct will be added to the "secondary" section
+seo()->section('secondary')->twitter('card', 'image');
+
+// This struct will be also added to the "default" section since the section() method changes are not persistent 
+seo()->twitter('card', 'summary');
+```
+
+### Rendering sections
+
+This will render all structs added to the "default" section.
+
+```blade
+{{ seo()->render() }}
+```
+
+This will render all structs added to the "secondary" section.
+
+```blade
+{{ seo()->section('secondary')->render() }}
+```
+
+Of course, you can also pass the section as parameter to the helper function.
+
+```blade
+{{ seo('secondary')->render() }}
+```
 
 ## Laravel-Mix Integration
 

--- a/docs/1-INDEX.md
+++ b/docs/1-INDEX.md
@@ -1,5 +1,6 @@
 - **[Basic Usage](1-INDEX.md)**
   - [Add Methods](1-INDEX.md#add-methods)
+  - [Sections](1-INDEX.md#sections)
   - [Macros](1-INDEX.md#macros)
 - [Structs](2-STRUCTS.md)
   - [Available Shorthand Methods](2-STRUCTS.md#available-shorthand-methods)
@@ -137,6 +138,70 @@ seo()->addFromArray([
 
 ```php
 seo()->clearStructs();
+```
+
+## Sections
+
+You can add structs to different **sections** by calling the `section('foo')` method on the `SeoService` instance or passing it as the first attribute to the `seo('foo')` helper method. By default all Structs will be added to the "default" section.
+
+Sections allow you to create certain namespaces for Structs which can be used in many different ways: Distinct between "frontend" and "admin" page sections or "head" and "body" view sections.
+
+### Using sections
+
+```php
+// This struct will be added to the "default" section
+seo()->twitter('card', 'summary');
+
+// This struct will be added to the "secondary" section
+seo()->section('secondary')->twitter('card', 'image');
+
+// This struct will be also added to the "default" section since the section() method changes are not persistent 
+seo()->twitter('card', 'summary');
+```
+
+You can also pass the section as parameter to the helper function.
+
+```php
+seo('secondary')->twitter('card', 'image');
+```
+
+### Rendering sections
+
+This will render all structs added to the "default" section.
+
+```blade
+{{ seo()->render() }}
+```
+
+This will render all structs added to the "secondary" section.
+
+```blade
+{{ seo()->section('secondary')->render() }}
+```
+
+Of course, you can also pass the section as parameter to the helper function.
+
+```blade
+{{ seo('secondary')->render() }}
+```
+
+### Using sections with dependency resolving
+
+```php
+use romanzipp\Seo\Services\SeoService;
+
+$seo = app(SeoService::class);
+
+// will be applied to "default" section
+$seo->twitter('card', 'summary');
+
+// will be applied to "secondary" section
+$seo->section('secondary')->twitter('card', 'summary');
+
+// WARNING!
+// This struct will be applied to the "secondary" section since the service instance has been resolved
+// once and was set to "secondary" section in the previous step
+$seo->twitter('card', 'summary');
 ```
 
 ## Macros

--- a/docs/2-STRUCTS.md
+++ b/docs/2-STRUCTS.md
@@ -1,5 +1,6 @@
 - [Basic Usage](1-INDEX.md)
   - [Add Methods](1-INDEX.md#add-methods)
+  - [Sections](1-INDEX.md#sections)
   - [Macros](1-INDEX.md#macros)
 - **[Structs](2-STRUCTS.md)**
   - [Available Shorthand Methods](2-STRUCTS.md#available-shorthand-methods)

--- a/docs/3-HOOKS.md
+++ b/docs/3-HOOKS.md
@@ -1,5 +1,6 @@
 - [Basic Usage](1-INDEX.md)
   - [Add Methods](1-INDEX.md#add-methods)
+  - [Sections](1-INDEX.md#sections)
   - [Macros](1-INDEX.md#macros)
 - [Structs](2-STRUCTS.md)
   - [Available Shorthand Methods](2-STRUCTS.md#available-shorthand-methods)

--- a/docs/4-LARAVEL-MIX.md
+++ b/docs/4-LARAVEL-MIX.md
@@ -1,5 +1,6 @@
 - [Basic Usage](1-INDEX.md)
   - [Add Methods](1-INDEX.md#add-methods)
+  - [Sections](1-INDEX.md#sections)
   - [Macros](1-INDEX.md#macros)
 - [Structs](2-STRUCTS.md)
   - [Available Shorthand Methods](2-STRUCTS.md#available-shorthand-methods)

--- a/docs/5-EXAMPLE-APP.md
+++ b/docs/5-EXAMPLE-APP.md
@@ -1,5 +1,6 @@
 - [Basic Usage](1-INDEX.md)
   - [Add Methods](1-INDEX.md#add-methods)
+  - [Sections](1-INDEX.md#sections)
   - [Macros](1-INDEX.md#macros)
 - [Structs](2-STRUCTS.md)
   - [Available Shorthand Methods](2-STRUCTS.md#available-shorthand-methods)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 - [Basic Usage](1-INDEX.md)
   - [Add Methods](1-INDEX.md#add-methods)
+  - [Sections](1-INDEX.md#sections)
   - [Macros](1-INDEX.md#macros)
 - [Structs](2-STRUCTS.md)
   - [Available Shorthand Methods](2-STRUCTS.md#available-shorthand-methods)

--- a/src/Collections/Contracts/CollectionContract.php
+++ b/src/Collections/Contracts/CollectionContract.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace romanzipp\Seo\Collections\Contracts;
+
+interface CollectionContract
+{
+
+}

--- a/src/Collections/SchemaCollection.php
+++ b/src/Collections/SchemaCollection.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace romanzipp\Seo\Collections;
+
+use romanzipp\Seo\Collections\Contracts\CollectionContract;
+use Spatie\SchemaOrg\Type;
+
+class SchemaCollection implements CollectionContract
+{
+    /**
+     * @var \Spatie\SchemaOrg\Type[]
+     */
+    protected $schemas = [];
+
+    /**
+     * @return \Spatie\SchemaOrg\Type[]
+     */
+    public function all(): array
+    {
+        return $this->schemas;
+    }
+
+    public function add(Type $schema): void
+    {
+        $this->schemas[] = $schema;
+    }
+
+    /**
+     * @param \Spatie\SchemaOrg\Type[] $schemas
+     */
+    public function set(array $schemas): void
+    {
+        $this->schemas = $schemas;
+    }
+}

--- a/src/Collections/StructCollection.php
+++ b/src/Collections/StructCollection.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace romanzipp\Seo\Collections;
+
+use romanzipp\Seo\Collections\Contracts\CollectionContract;
+use romanzipp\Seo\Structs\Struct;
+
+/**
+ * The Seo class functions as an intermediate layer between the laravel dependency container
+ * and the SeoService singleton instance.
+ *
+ * This intermediate class has been introduced to support the sections feature.
+ */
+class StructCollection implements CollectionContract
+{
+    /**
+     * @var \romanzipp\Seo\Structs\Struct[]
+     */
+    protected $structs = [];
+
+    /**
+     * @return \romanzipp\Seo\Structs\Struct[]
+     */
+    public function all(): array
+    {
+        return $this->structs;
+    }
+
+    public function add(Struct $struct): void
+    {
+        $this->structs[] = $struct;
+    }
+
+    /**
+     * @param \romanzipp\Seo\Structs\Struct[] $structs
+     */
+    public function set(array $structs): void
+    {
+        $this->structs = $structs;
+    }
+
+    public function unset(int $index): void
+    {
+        unset($this->structs[$index]);
+    }
+
+    public function remove(Struct $struct): void
+    {
+        $this->structs = array_filter($this->structs, function (Struct $existing) use ($struct): bool {
+            return $existing !== $struct;
+        });
+    }
+}

--- a/src/Conductors/MixManifestConductor.php
+++ b/src/Conductors/MixManifestConductor.php
@@ -77,7 +77,7 @@ class MixManifestConductor
     /**
      * Do not throw exception of the mix manifest is not found.
      *
-     * @return $this
+     * @return self
      */
     public function ignore(): self
     {

--- a/src/Providers/SeoServiceProvider.php
+++ b/src/Providers/SeoServiceProvider.php
@@ -34,8 +34,6 @@ class SeoServiceProvider extends ServiceProvider
             'seo'
         );
 
-        $this->app->singleton(SeoService::class, function () {
-            return new SeoService();
         $this->app->singleton(StructCollection::class, function (Application $app) {
             return new StructCollection();
         });
@@ -43,6 +41,12 @@ class SeoServiceProvider extends ServiceProvider
         $this->app->singleton(SchemaCollection::class, function (Application $app) {
             return new SchemaCollection();
         });
+
+        $this->app->bind(SeoService::class, function (Application $app) {
+            return new SeoService(
+                $app->make(StructCollection::class),
+                $app->make(SchemaCollection::class)
+            );
         });
     }
 

--- a/src/Providers/SeoServiceProvider.php
+++ b/src/Providers/SeoServiceProvider.php
@@ -2,7 +2,10 @@
 
 namespace romanzipp\Seo\Providers;
 
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
+use romanzipp\Seo\Collections\SchemaCollection;
+use romanzipp\Seo\Collections\StructCollection;
 use romanzipp\Seo\Services\SeoService;
 
 class SeoServiceProvider extends ServiceProvider
@@ -33,6 +36,13 @@ class SeoServiceProvider extends ServiceProvider
 
         $this->app->singleton(SeoService::class, function () {
             return new SeoService();
+        $this->app->singleton(StructCollection::class, function (Application $app) {
+            return new StructCollection();
+        });
+
+        $this->app->singleton(SchemaCollection::class, function (Application $app) {
+            return new SchemaCollection();
+        });
         });
     }
 

--- a/src/Services/SeoService.php
+++ b/src/Services/SeoService.php
@@ -119,16 +119,19 @@ class SeoService
      */
     public function clearStructs(): void
     {
-        $this->setStructs([]);
+        $this->structs = [];
     }
 
     /**
-     * Append struct.
+     * Append a given struct. This is an internal method called by all add/set public methods
+     * which also sets the current section to the struct.
      *
      * @param \romanzipp\Seo\Structs\Struct $struct
      */
     public function appendStruct(Struct $struct): void
     {
+        $struct->setSection($this->section);
+
         $this->structs[] = $struct;
     }
 

--- a/src/Services/SeoService.php
+++ b/src/Services/SeoService.php
@@ -105,7 +105,11 @@ class SeoService
      */
     public function setStructs(array $structs): void
     {
-        $this->structs = $structs;
+        $this->clearStructs();
+
+        foreach ($structs as $struct) {
+            $this->appendStruct($struct);
+        }
     }
 
     /**

--- a/src/Services/SeoService.php
+++ b/src/Services/SeoService.php
@@ -81,14 +81,16 @@ class SeoService
         return $this->config;
     }
 
-    public function setSection(string $section): void
-    {
-        $this->section = $section;
-    }
-
+    /**
+     * Fluent section setter.
+     *
+     * @param string $section
+     *
+     * @return self
+     */
     public function section(string $section): self
     {
-        $this->setSection($section);
+        $this->section = $section;
 
         return $this;
     }
@@ -221,7 +223,7 @@ class SeoService
      *
      * @param array $data
      *
-     * @return $this
+     * @return self
      */
     public function addFromArray(array $data): self
     {

--- a/src/Services/SeoService.php
+++ b/src/Services/SeoService.php
@@ -141,6 +141,11 @@ class SeoService
         }
     }
 
+    /**
+     * Remove a struct from the collection by given array index.
+     *
+     * @param int $index
+     */
     public function unsetStruct(int $index): void
     {
         $this->structCollection->unset($index);

--- a/src/Services/Traits/CollisionTrait.php
+++ b/src/Services/Traits/CollisionTrait.php
@@ -6,6 +6,10 @@ use romanzipp\Seo\Structs\Struct;
 
 trait CollisionTrait
 {
+    abstract public function getStructs(): array;
+
+    abstract public function unsetStruct(int $index): void;
+
     /**
      * Remove struct from existing structs.
      *
@@ -25,7 +29,7 @@ trait CollisionTrait
             return;
         }
 
-        unset($this->structs[$key]);
+        $this->unsetStruct($key);
     }
 
     /**
@@ -41,7 +45,7 @@ trait CollisionTrait
             return null;
         }
 
-        foreach ($this->structs as $key => $existing) {
+        foreach ($this->getStructs() as $key => $existing) {
             /** @var \romanzipp\Seo\Structs\Struct $existing */
             if (get_class($existing) !== get_class($struct)) {
                 continue;

--- a/src/Services/Traits/SchemaOrgTrait.php
+++ b/src/Services/Traits/SchemaOrgTrait.php
@@ -15,7 +15,7 @@ trait SchemaOrgTrait
      */
     public function getSchemes(): array
     {
-        return $this->schemaOrgTypes;
+        return $this->schemaCollection->all();
     }
 
     /**
@@ -27,7 +27,7 @@ trait SchemaOrgTrait
      */
     public function addSchema(Type $schema): self
     {
-        $this->schemaOrgTypes[] = $schema;
+        $this->schemaCollection->add($schema);
 
         return $this;
     }
@@ -41,7 +41,7 @@ trait SchemaOrgTrait
      */
     public function setSchemes(array $types): self
     {
-        $this->schemaOrgTypes = $types;
+        $this->schemaCollection->set($types);
 
         return $this;
     }

--- a/src/Services/Traits/ShorthandSetterTrait.php
+++ b/src/Services/Traits/ShorthandSetterTrait.php
@@ -160,7 +160,7 @@ trait ShorthandSetterTrait
      *
      * @param string $charset
      *
-     * @return $this
+     * @return self
      */
     public function charset(string $charset = 'utf-8'): self
     {
@@ -174,7 +174,7 @@ trait ShorthandSetterTrait
      *
      * @param string $viewport
      *
-     * @return $this
+     * @return self
      */
     public function viewport(string $viewport = 'width=device-width, initial-scale=1'): self
     {
@@ -188,7 +188,7 @@ trait ShorthandSetterTrait
      *
      * @param string $canonical
      *
-     * @return $this
+     * @return self
      */
     public function canonical(string $canonical): self
     {
@@ -202,7 +202,7 @@ trait ShorthandSetterTrait
      *
      * @param string|null $token
      *
-     * @return $this
+     * @return self
      */
     public function csrfToken(string $token = null): self
     {

--- a/src/Structs/Struct.php
+++ b/src/Structs/Struct.php
@@ -193,7 +193,7 @@ abstract class Struct
      *
      * @param string $section
      *
-     * @return $this
+     * @return self
      */
     public function setSection(string $section): Struct
     {
@@ -276,7 +276,7 @@ abstract class Struct
      * @param array $attributes
      * @param bool $escape
      *
-     * @return $this
+     * @return self
      */
     public function attrs(array $attributes, bool $escape = true): Struct
     {

--- a/src/Structs/Struct.php
+++ b/src/Structs/Struct.php
@@ -42,6 +42,11 @@ abstract class Struct
     protected $body = null;
 
     /**
+     * @var string
+     */
+    protected $section;
+
+    /**
      * Constructor.
      */
     public function __construct()
@@ -169,6 +174,30 @@ abstract class Struct
     public function setUnique(bool $unique = true): Struct
     {
         $this->unique = $unique;
+
+        return $this;
+    }
+
+    /**
+     * Get the section in which the struct should rest. Default: "default".
+     *
+     * @return string
+     */
+    public function getSection(): string
+    {
+        return $this->section;
+    }
+
+    /**
+     * Set the section. This is mainly done in the SeoService class.
+     *
+     * @param string $section
+     *
+     * @return $this
+     */
+    public function setSection(string $section): Struct
+    {
+        $this->section = $section;
 
         return $this;
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -6,10 +6,15 @@ if ( ! function_exists('seo')) {
     /**
      * Create SeoService instance.
      *
+     * @param string|null $section
      * @return \romanzipp\Seo\Services\SeoService
      */
-    function seo(): SeoService
+    function seo(string $section = null): SeoService
     {
-        return app(SeoService::class);
+        if (null === $section) {
+            return app(SeoService::class);
+        }
+
+        return app(SeoService::class)->section($section);
     }
 }

--- a/tests/SectionsTest.php
+++ b/tests/SectionsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace romanzipp\Seo\Test;
+
+use romanzipp\Seo\Structs\Meta;
+
+class SectionsTest extends TestCase
+{
+    public function testDefaultSection()
+    {
+        seo()->twitter('card', 'default');
+
+        self::assertSame(
+            seo()->section('default')->getStructs(),
+            seo()->getStructs()
+        );
+    }
+
+    public function testDefaultSectionExplicitlyDeclared()
+    {
+        seo()->section('default')->twitter('card', 'default');
+
+        self::assertSame(
+            seo()->section('default')->getStructs(),
+            seo()->getStructs()
+        );
+    }
+
+    public function testDefaultSectionUntouched()
+    {
+        seo()->section('secondary')->twitter('card', 'default');
+
+        self::assertSame(
+            seo()->section('default')->getStructs(),
+            seo()->getStructs()
+        );
+    }
+
+    public function testSectionsDoNotMatch()
+    {
+        seo()
+            ->add(Meta::make()->attr('section', 'default'));
+
+        seo()
+            ->section('secondary')
+            ->add(Meta::make()->attr('section', 'secondary'));
+
+        self::assertCount(1, seo()->getStructs());
+        self::assertSame('default', (string) seo()->getStruct(Meta::class)->getComputedAttribute('section'));
+
+        self::assertCount(1, seo()->section('default')->getStructs());
+        self::assertSame('default', (string) seo()->section('default')->getStruct(Meta::class)->getComputedAttribute('section'));
+
+        self::assertCount(1, seo()->section('secondary')->getStructs());
+        self::assertSame('secondary', (string) seo()->section('secondary')->getStruct(Meta::class)->getComputedAttribute('section'));
+    }
+}

--- a/tests/SectionsTest.php
+++ b/tests/SectionsTest.php
@@ -2,6 +2,7 @@
 
 namespace romanzipp\Seo\Test;
 
+use romanzipp\Seo\Services\SeoService;
 use romanzipp\Seo\Structs\Meta;
 
 class SectionsTest extends TestCase
@@ -53,5 +54,54 @@ class SectionsTest extends TestCase
 
         self::assertCount(1, seo()->section('secondary')->getStructs());
         self::assertSame('secondary', (string) seo()->section('secondary')->getStruct(Meta::class)->getComputedAttribute('section'));
+    }
+
+    public function testSectionPassedAsParameterToHelper()
+    {
+        seo('secondary')->twitter('card', 'default');
+
+        self::assertSame(
+            seo()->section('secondary')->getStructs(),
+            seo('secondary')->getStructs()
+        );
+    }
+
+    public function testSectionSetterOnMutableInstance()
+    {
+        $seo = app(SeoService::class);
+
+        $seo->section('secondary');
+
+        $seo->twitter('card', 'default');
+        $seo->twitter('author', 'Roman');
+
+        self::assertCount(2, $seo->getStructs());
+
+        self::assertSame(
+            $seo->getStructs(),
+            seo('secondary')->getStructs()
+        );
+    }
+
+    public function testSectionRender()
+    {
+        seo()->twitter('card', 'default');
+
+        seo()->section('secondary')->twitter('card', 'secondary');
+
+        self::assertEquals(
+            '<meta name="twitter:card" content="default" />',
+            seo()->render()->toHtml()
+        );
+
+        self::assertEquals(
+            '<meta name="twitter:card" content="secondary" />',
+            seo()->section('secondary')->render()->toHtml()
+        );
+
+        self::assertEquals(
+            '<meta name="twitter:card" content="secondary" />',
+            seo('secondary')->render()->toHtml()
+        );
     }
 }

--- a/tests/SetterTest.php
+++ b/tests/SetterTest.php
@@ -24,7 +24,7 @@ class SetterTest extends TestCase
 
         self::assertCount(1, seo()->getStructs());
 
-        seo()->setStructs([
+        seo()->setStructCollection([
             OpenGraph::make(),
         ]);
 

--- a/tests/SetterTest.php
+++ b/tests/SetterTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace romanzipp\Seo\Test;
+
+use romanzipp\Seo\Structs\Meta\OpenGraph;
+use romanzipp\Seo\Structs\Meta\Twitter;
+
+class SetterTest extends TestCase
+{
+    public function testClear()
+    {
+        seo()->twitter('card', 'image');
+
+        self::assertCount(1, seo()->getStructs());
+
+        seo()->clearStructs();
+
+        self::assertCount(0, seo()->getStructs());
+    }
+
+    public function testSetOverride()
+    {
+        seo()->twitter('card', 'image');
+
+        self::assertCount(1, seo()->getStructs());
+
+        seo()->setStructs([
+            OpenGraph::make(),
+        ]);
+
+        self::assertCount(1, seo()->getStructs());
+        self::assertInstanceOf(OpenGraph::class, seo()->getStruct(OpenGraph::class));
+    }
+
+    public function testAdd()
+    {
+        seo()->add(Twitter::make());
+
+        self::assertCount(1, seo()->getStructs());
+
+        seo()->add(OpenGraph::make());
+
+        self::assertCount(2, seo()->getStructs());
+    }
+
+    public function testAddIf()
+    {
+        seo()->addIf(false, Twitter::make());
+
+        self::assertCount(0, seo()->getStructs());
+
+        seo()->addIf(true, Twitter::make());
+
+        self::assertCount(1, seo()->getStructs());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,11 +4,19 @@ namespace romanzipp\Seo\Test;
 
 use Orchestra\Testbench\TestCase as BaseTestCase;
 use PHPUnit\Framework\Constraint\RegularExpression;
+use romanzipp\Seo\Builders\StructBuilder;
 use romanzipp\Seo\Facades\Seo;
 use romanzipp\Seo\Providers\SeoServiceProvider;
 
 abstract class TestCase extends BaseTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        StructBuilder::$separator = PHP_EOL;
+        StructBuilder::$indent = null;
+    }
     protected function getPackageProviders($app)
     {
         return [


### PR DESCRIPTION
This PR introduces a new **sections** feature which allows developers to add Structs to certains sections of their app.
All changes are fully backwards compatible.

These can be implemented as a distiction between "frontend" and "admin" or "head" and "body".

### Using sections with helper method

```php
// will be applied to "default" section
seo()->twitter('card', 'summary');

// will be applied to "secondary" section
seo()->section('secondary')->twitter('card', 'summary');

// will also be applied to "default" section
seo()->twitter('card', 'summary');
```

You can also pass the section name as a single argument to the helper function.

```php
seo('secondary')->twitter('card', 'summary');
```

### Using sections with dependency resolving

```php
$seo = app(SeoService::class);

// will be applied to "default" section
$seo->twitter('card', 'summary');

// will be applied to "secondary" section
$seo->section('secondary')->twitter('card', 'summary');

// WARNING!
// This struct will be applied to the "secondary" section since the service instace has been resolved
// once and was set to "secondary" section in the previous step
$seo->twitter('card', 'summary');
```

### Render

```blade
{{ seo()->render() }}

{{ seo('secondary')->render() }}
```

### How it works

The structs have been moved to a new `StructCollection` which will be resolved as a singleton instance by the Laravel container.

The eixsting `SeoService` has been modified to a passthrough class accessing the struct collection.